### PR TITLE
Fix GPG key error in GraphVis Docker build

### DIFF
--- a/GraphVis/Dockerfile
+++ b/GraphVis/Dockerfile
@@ -15,6 +15,9 @@ USER root
 
 SHELL ["/bin/bash", "-Eeox", "pipefail", "-c"]
 
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+
 RUN apt update \
  && DEBIAN_FRONTEND=noninteractive \
     apt install -y --no-install-recommends \


### PR DESCRIPTION
Update GraphVis Dockerfile to fix the following error that happens during `apt update`:

```
#11 3.087 Reading package lists...
#11 3.862 W: GPG error: https://apt.kitware.com/ubuntu focal InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 42D5A192B819C5DA
#11 3.862 E: The repository 'https://apt.kitware.com/ubuntu focal InRelease' is not signed.
```