### PR TITLE
Update DFP Viz to use node-rapids 22.8.2

### DIFF
--- a/DFP/package.json
+++ b/DFP/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morpheus-fingerprint-viz",
-  "version": "22.11.00",
+  "version": "23.07.00",
   "private": true,
   "scripts": {
     "dev": "CUDA_VISIBLE_DEVICES=0 next dev",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@observablehq/plot": "^0.6.0",
-    "@rapidsai/cudf": "^22.8.1",
+    "@rapidsai/cudf": "^22.8.2",
     "@react-three/drei": "^9.40.0",
     "@react-three/fiber": "^8.9.1",
     "apache-arrow": "^9.0.0",


### PR DESCRIPTION
## Description
- Update to `node-rapids` 22.8.2
- Fixes [libnvrtc error](https://github.com/nv-morpheus/Morpheus/issues/882#issuecomment-1507402400) in DFP Viz

## Checklist
[ ] I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
[ ] New or existing tests cover these changes.
[ ] The documentation is up to date with these changes.
