### PR TITLE
[RELEASE] morpheus-visualizations v24.06.00

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Version
       description: What version of Morpheus are you running?
-      placeholder: "example: 24.03"
+      placeholder: "example: 24.06"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# morpheus-visualizations 24.06.00 (02 Jul 2024)
+There are no changes for v24.06.00.
+
 # morpheus-visualizations 23.11.00 (30 Nov 2023)
 
 ## 🛠️ Improvements

--- a/DFP/package.json
+++ b/DFP/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morpheus-fingerprint-viz",
-  "version": "24.03.00",
+  "version": "24.06.00",
   "private": true,
   "scripts": {
     "dev": "CUDA_VISIBLE_DEVICES=0 next dev",


### PR DESCRIPTION
## :snowflake: Code freeze for `branch-24.06` and `v24.06` release

### What does this mean?
Only critical/hotfix level issues should be merged into `branch-24.06` until release (merging of this PR).

All other development PRs should be retargeted towards the next release branch: `branch-24.10`.

### What is the purpose of this PR?
- Update documentation
- Allow testing for the new release
- Enable a means to merge `branch-24.06` into `main` for the release
