### PR TITLE
[RELEASE] morpheus-visualizations v25.02.00

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Version
       description: What version of Morpheus are you running?
-      placeholder: "example: 24.10"
+      placeholder: "example: 25.02"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# morpheus-visualizations 25.02.00 (03 Feb 2025)
+There are no changes for v25.02.00
+
 # morpheus-visualizations 24.10.00 (01 Nov 2024)
 
 ## 🐛 Bug Fixes

--- a/DFP/package.json
+++ b/DFP/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morpheus-fingerprint-viz",
-  "version": "24.10.00",
+  "version": "25.02.00",
   "private": true,
   "scripts": {
     "dev": "CUDA_VISIBLE_DEVICES=0 next dev",


### PR DESCRIPTION
## :snowflake: Code freeze for `branch-25.02` and `v25.02` release

### What does this mean?
Only critical/hotfix level issues should be merged into `branch-25.02` until release (merging of this PR).

All other development PRs should be retargeted towards the next release branch: `branch-25.06`.

### What is the purpose of this PR?
- Update documentation
- Allow testing for the new release
- Enable a means to merge `branch-25.02` into `main` for the release
